### PR TITLE
Update `OTPChallenge` coding key.

### DIFF
--- a/Sources/RelyingPartyKit/Models/User.swift
+++ b/Sources/RelyingPartyKit/Models/User.swift
@@ -31,6 +31,12 @@ public struct OTPChallenge: Decodable {
     
     /// The time when the verification expires.
     public let expiry: Date
+    
+    private enum CodingKeys: String, CodingKey {
+        case transactionId = "id"
+        case correlation
+        case expiry
+    }
 }
 
 /// A strucutre that describes a one-time password verification.

--- a/Sources/RelyingPartyKit/appscan-config.xml
+++ b/Sources/RelyingPartyKit/appscan-config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<Configuration>
-  <Targets>
-    <Target path=""/>
-  </Targets>
-</Configuration>


### PR DESCRIPTION
The JSON response payload maps `id` to `transactionId` using the code key.